### PR TITLE
Remove ‘//‘ in the mail to field

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -130,7 +130,7 @@
                     <div class="col-md-1 col-sm-2 col-xs-6">
                         <div class="title">Contact</div>
                         <ul class="sm">
-                            <li><a href="mailto://swaranotebook@gmail.com"><i class="fa fa-envelope-open fa-2x"></i></a></li>
+                            <li><a href="mailto:swaranotebook@gmail.com"><i class="fa fa-envelope-open fa-2x"></i></a></li>
                             <li><a href="https://github.com/Studio-kalavati/Swaranotebook-bandish-editor"><i class="fa fa-github fa-2x"></i></a></li>
                         </ul>
                     </div>


### PR DESCRIPTION
The email button opens 
"//swaranotebook@gmail.com" 
instead of 
"swaranotebook@gmail.com" . 

Probably this is due to using 
"mailto://" instead of "mailto:"