### PR TITLE
pad svaras when lyrics overlap

### DIFF
--- a/src/bhatkhande_editor/views.cljs
+++ b/src/bhatkhande_editor/views.cljs
@@ -1006,8 +1006,6 @@
                                                          {:x (+ x1 (int (* 0.3 @font-size)))
                                                           :y (int (* 1.7 @font-size))
                                                           :style {:font-size (* 0.5 @font-size)}} sah])]
-                                                   (println "len of sah " (count sah)
-                                                            " -- "(+ x1 (int (* 0.3 @font-size))))
                                                    (if (> 2 (count sah))
                                                      r4
                                                      (-> r4

--- a/src/bhatkhande_editor/views.cljs
+++ b/src/bhatkhande_editor/views.cljs
@@ -998,15 +998,21 @@
                                                 r3)))
                                           r3 (if-let [sah (get sah-list note-index)]
                                                (if (= nsi 0)
-                                                 (-> r3
-                                                     (update-in
-                                                      [:images1]
-                                                      conj
-                                                      [:text
-                                                       {;;:x (+ 10 x1) :y 60
-                                                        :x (+ x1 (int (* 0.3 @font-size)))
-                                                        :y (int (* 1.7 @font-size))
-                                                        :style {:font-size (* 0.5 @font-size)}} sah]))
+                                                 (let [r4
+                                                       (update-in r3
+                                                        [:images1]
+                                                        conj
+                                                        [:text
+                                                         {:x (+ x1 (int (* 0.3 @font-size)))
+                                                          :y (int (* 1.7 @font-size))
+                                                          :style {:font-size (* 0.5 @font-size)}} sah])]
+                                                   (println "len of sah " (count sah)
+                                                            " -- "(+ x1 (int (* 0.3 @font-size))))
+                                                   (if (> 2 (count sah))
+                                                     r4
+                                                     (-> r4
+                                                         (update-in [:x1] + (int (* (* 0.3 (count sah))
+                                                                                    (* 0.7 @font-size)))))))
                                                  r3)
                                                r3)]
                                       r3))


### PR DESCRIPTION
When the lyrics are longer than 2 characters, pad the svaras so that the y-axis start is after the lyrics end