### PR TITLE
Fix for #180 - if empty name, use the default comp title

### DIFF
--- a/src/bhatkhande_editor/events.cljs
+++ b/src/bhatkhande_editor/events.cljs
@@ -630,7 +630,7 @@
            (dispatch [::set-active-panel :home-panel]))))))
 
 (def ^:private url-allowed
-  #"[\-._~:/?#\[\]@!$&'()*+,;=%]")
+  #"[\._~:/?#\[\]@!$&'()*+,;=%]")
 
 (defn sanitize-url
   "Removes characters not allowed in a full URL. Optionally normalizes spaces to '-'."
@@ -648,9 +648,9 @@
                (update-in db [:composition :title] (constantly comp-title))
                db)
          comp (-> (-> ndb :composition) to-trans)
-         path (sanitize-url
-               (str (last (.split (.toString (random-uuid)) #"-"))
-                    "-" comp-title))]
+         pre-sanitized-url (str (last (.split (.toString (random-uuid)) #"-"))
+                               "-" comp-title)
+         path (sanitize-url pre-sanitized-url)]
      (upload-comp (-> ndb :user :uid) path comp)
      {:dispatch [::set-active-panel :wait-for-save-completion]
       :db ndb})))

--- a/src/bhatkhande_editor/views.cljs
+++ b/src/bhatkhande_editor/views.cljs
@@ -1231,31 +1231,11 @@
                                                                             (let [new-sahitya
                                                                                   (clojure.string/split x #",")]
                                                                               (dispatch [::events/conj-sahitya
-                                                                                         (assoc cursor-map :text-val new-sahitya)])))]))
-                                                         [input-text
-                                                               :model "abcd"
-                                                               :class "overlay-text"
-                                                               :style {:font-size (* 0.8 @font-size)
-                                                                       :height (* 1 @font-size)
-                                                                       :border "1px dotted gray"
-                                                                       :caret-color "black"
-                                                                       :width "96%"
-                                                                       }
-                                                               :on-change (fn[x]
-                                                                            (println " aa "))]]]
+                                                                                         (assoc cursor-map :text-val new-sahitya)])))]))]]
                                                 res))
                                             row)
                                            vec)]
-                                  (->> (map-indexed (fn[bhaag-indx i] [bhaag-indx i]) res0)
-                                       (reduce (fn[acc [bhaag-indx i]]
-                                                 (into acc
-                                                       [i
-                                                        [box :align :center
-                                                         :child [md-icon-button
-                                                                 :md-icon-name "zmdi zmdi-comment-outline"
-                                                                 :on-click (fn[]
-                                                                             (do (println " click " score-part-index avartan-index bhaag-indx)))]]
-                                                            ])) [])))))
+                                  res0)))
                              vec)
                         part-header
                         [h-box

--- a/src/bhatkhande_editor/views.cljs
+++ b/src/bhatkhande_editor/views.cljs
@@ -558,7 +558,7 @@
                                    :child
                                    [input-text
                                     :src (at)
-                                    :model (or @(subscribe [::subs/comp-title]) title-val)
+                                    :model (or @(subscribe [::subs/comp-title]) @title-val)
                                     :style {:font-size "large" :width "100%"
                                             :justify-content "center"
                                             :text-align "center"}
@@ -566,8 +566,14 @@
                                   [button
                                    :label " Save "
                                    :class "btn-hc-lg btn-primary "
-                                   :on-click #(let [tv (cstring/replace @title-val
-                                                                        #" " "-")]
+                                   :on-click
+                                   #(let [use-title
+                                          ;; if title has been edited, use title-val
+                                          ;; if its not edited, then its empty, so use the default comp-title
+                                          (if (= @title-val "")
+                                                      @(subscribe [::subs/comp-title])
+                                                      @title-val)
+                                          tv (cstring/replace use-title #" " "-")]
                                                 (reset! show-title-popup? false)
                                                 (dispatch [::events/upload-new-comp tv]))]]]]])
                      (when @show-login-popup?
@@ -1225,11 +1231,31 @@
                                                                             (let [new-sahitya
                                                                                   (clojure.string/split x #",")]
                                                                               (dispatch [::events/conj-sahitya
-                                                                                         (assoc cursor-map :text-val new-sahitya)])))]))]]
+                                                                                         (assoc cursor-map :text-val new-sahitya)])))]))
+                                                         [input-text
+                                                               :model "abcd"
+                                                               :class "overlay-text"
+                                                               :style {:font-size (* 0.8 @font-size)
+                                                                       :height (* 1 @font-size)
+                                                                       :border "1px dotted gray"
+                                                                       :caret-color "black"
+                                                                       :width "96%"
+                                                                       }
+                                                               :on-change (fn[x]
+                                                                            (println " aa "))]]]
                                                 res))
                                             row)
                                            vec)]
-                                  res0)))
+                                  (->> (map-indexed (fn[bhaag-indx i] [bhaag-indx i]) res0)
+                                       (reduce (fn[acc [bhaag-indx i]]
+                                                 (into acc
+                                                       [i
+                                                        [box :align :center
+                                                         :child [md-icon-button
+                                                                 :md-icon-name "zmdi zmdi-comment-outline"
+                                                                 :on-click (fn[]
+                                                                             (do (println " click " score-part-index avartan-index bhaag-indx)))]]
+                                                            ])) [])))))
                              vec)
                         part-header
                         [h-box


### PR DESCRIPTION
When the default title Bandish name was used, it ended up being empty. Changed to use the comp-title if empty or ""

Secondly, sanitize-url was removing hyphens. The part after the first hyphen was the name of the composition used in the list.